### PR TITLE
feat: Add MCP Compatible badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FArcBlock%2Fmyvibe-skills%2Fmain%2F.claude-plugin%2Fmarketplace.json&query=%24.metadata.version&label=version&style=for-the-badge&color=blue" alt="Version">
   <img src="https://img.shields.io/badge/Agent_Skill-blueviolet?style=for-the-badge" alt="Agent Skill">
+  <img src="https://img.shields.io/badge/MCP-Compatible-blue?style=for-the-badge" alt="MCP Compatible">
   <a href="https://github.com/ArcBlock/myvibe-skills/blob/main/LICENSE.md">
     <img src="https://img.shields.io/badge/license-ELv2-green?style=for-the-badge" alt="License">
   </a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,6 +7,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FArcBlock%2Fmyvibe-skills%2Fmain%2F.claude-plugin%2Fmarketplace.json&query=%24.metadata.version&label=version&style=for-the-badge&color=blue" alt="Version">
   <img src="https://img.shields.io/badge/Agent_Skill-blueviolet?style=for-the-badge" alt="Agent Skill">
+  <img src="https://img.shields.io/badge/MCP-Compatible-blue?style=for-the-badge" alt="MCP Compatible">
   <a href="https://github.com/ArcBlock/myvibe-skills/blob/main/LICENSE.md">
     <img src="https://img.shields.io/badge/license-ELv2-green?style=for-the-badge" alt="License">
   </a>


### PR DESCRIPTION
## Summary
- Added MCP Compatible badge to both English and Chinese README files
- Uses `for-the-badge` style consistent with existing badges
- Signals ecosystem compatibility for MCP server directories (Smithery.ai, Glama, etc.)

## Preview
The badge will appear in the header alongside existing badges:

![MCP Compatible](https://img.shields.io/badge/MCP-Compatible-blue?style=for-the-badge)

## Test plan
- [x] Verify badge renders correctly in both README.md and README.zh.md
- [x] Ensure badge style matches existing badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)