### PR TITLE
feat: support OpenAI Codex agent detection

### DIFF
--- a/skills/myvibe-publish/scripts/utils/auth.mjs
+++ b/skills/myvibe-publish/scripts/utils/auth.mjs
@@ -163,6 +163,9 @@ export async function handleAuthError(hubUrl, statusCode) {
 
 
 function getAgentName() {
+  if (process.env.CODEX) {
+    return 'Codex';
+  }
   if (process.env.CLAUDECODE) {
     return 'Claude Code';
   }


### PR DESCRIPTION
## Summary

Adds OpenAI Codex environment variable detection to `getAgentName()` in `auth.mjs`, so the authorization flow correctly identifies Codex as the agent platform.

## Changes

- Added `CODEX` env var check in `getAgentName()` (3 lines)

## Context

We submitted the MyVibe Publish skill to the [OpenAI Codex Skills Catalog](https://github.com/openai/skills/pull/113). This backports the Codex detection that was added in that submission.

## Related

- Codex skills PR: https://github.com/openai/skills/pull/113
- Tracking issue: #8
- License issue: #9